### PR TITLE
MARP-2306 New variable to define moving email method

### DIFF
--- a/mailstore-connector/config/variables.yaml
+++ b/mailstore-connector/config/variables.yaml
@@ -48,6 +48,14 @@ Variables:
       scope: ''
       #[client_credentials, password]
       grantType: ''
+      # The method used to move messages. Default is <pre>append</pre>; change to
+      # <pre>copy</pre> if you encounter performance issues when moving mail.
+      # <ul>
+      #   <li><pre>append</pre> uses <code>appendMessages</code></li>
+      #   <li><pre>copy</pre> uses <code>copyMessages</code></li>
+      # </ul>
+      # Options: [append, copy]]
+      movingMethod: ''
       
   # login microsoft azure
   azureOAuth:

--- a/mailstore-connector/src/com/axonivy/connector/mailstore/MailStoreService.java
+++ b/mailstore-connector/src/com/axonivy/connector/mailstore/MailStoreService.java
@@ -547,15 +547,15 @@ public class MailStoreService {
 					Message current = messages[nextIndex - 1];
 					subject = MailStoreService.toString(current);
 					try {
-						Folder dstFolder = StringUtils.isBlank(dstFolderName) ? getFirstEmailFolder()
-								: dstFolderMap.get(dstFolderName);
+						Folder dstFolder =
+								StringUtils.isBlank(dstFolderName) ? getFirstEmailFolder() : dstFolderMap.get(dstFolderName);
 						if (dstFolder != null) {
 							dstFolderName = dstFolder.getName();
 							LOG.debug("Appending {0} to {1} folder", subject, dstFolderName);
 							if (mailMovingMethod == MailMovingMethod.APPEND) {
-								dstFolderMap.get(dstFolderName).appendMessages(new Message[] { current });
+								dstFolderMap.get(dstFolderName).appendMessages(new Message[] {current});
 							} else {
-								srcFolder.copyMessages(new Message[] { current }, dstFolderMap.get(dstFolderName));
+								srcFolder.copyMessages(new Message[] {current}, dstFolderMap.get(dstFolderName));
 							}
 						}
 					} finally {
@@ -575,7 +575,7 @@ public class MailStoreService {
 			}
 		}
 	}
-	
+
 	/**
 	 * Get the raw message data e.g. for saving.
 	 * 

--- a/mailstore-connector/src/com/axonivy/connector/mailstore/enums/MailMovingMethod.java
+++ b/mailstore-connector/src/com/axonivy/connector/mailstore/enums/MailMovingMethod.java
@@ -19,15 +19,14 @@ public enum MailMovingMethod {
 	APPEND, COPY;
 
 	/**
-     * Parses the input string and returns the corresponding {@code MailMovingMethod}.
-     * The comparison is case-insensitive and trims any leading/trailing whitespace.
-     *
-     * @param name the name of the mail moving method to parse
-     * @return the matching {@code MailMovingMethod}, or {@code APPEND} if no match is found
-     */
+	 * Parses the input string and returns the corresponding {@code MailMovingMethod}.
+	 * The comparison is case-insensitive and trims any leading/trailing whitespace.
+	 *
+	 * @param name the name of the mail moving method to parse
+	 * @return the matching {@code MailMovingMethod}, or {@code APPEND} if no match is found
+	 */
 	public static MailMovingMethod from(String name) {
 		return Stream.of(MailMovingMethod.values())
-				.filter(method -> StringUtils.equalsIgnoreCase(method.name(), StringUtils.trim(name))).findAny()
-				.orElse(APPEND);
+				.filter(method -> StringUtils.equalsIgnoreCase(method.name(), StringUtils.trim(name))).findAny().orElse(APPEND);
 	}
 }

--- a/mailstore-connector/src/com/axonivy/connector/mailstore/enums/MailMovingMethod.java
+++ b/mailstore-connector/src/com/axonivy/connector/mailstore/enums/MailMovingMethod.java
@@ -1,0 +1,33 @@
+package com.axonivy.connector.mailstore.enums;
+
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Enum representing the method of moving emails in an IMAP mailbox.
+ *
+ * <p>
+ * There are two supported methods:
+ * <ul>
+ *   <li>{@link #APPEND} - Use the {@code appendMessages} function to move emails.</li>
+ *   <li>{@link #COPY} - Use the {@code copyMessages} function to move emails.</li>
+ * </ul>
+ * </p>
+ */
+public enum MailMovingMethod {
+	APPEND, COPY;
+
+	/**
+     * Parses the input string and returns the corresponding {@code MailMovingMethod}.
+     * The comparison is case-insensitive and trims any leading/trailing whitespace.
+     *
+     * @param name the name of the mail moving method to parse
+     * @return the matching {@code MailMovingMethod}, or {@code APPEND} if no match is found
+     */
+	public static MailMovingMethod from(String name) {
+		return Stream.of(MailMovingMethod.values())
+				.filter(method -> StringUtils.equalsIgnoreCase(method.name(), StringUtils.trim(name))).findAny()
+				.orElse(APPEND);
+	}
+}


### PR DESCRIPTION
Add a new variable `movingMethod` to allow the user to switch between the two functions `appendMessages` and `copyMessages `for moving emails.
Ticket: https://1ivy.atlassian.net/browse/MARP-2306
This PR is intended to apply the changes to the LTS 10 version. A separate PR for version 12 will be created later by cherry-picking, if this one is reviewed and approved.

